### PR TITLE
chore: upgrade to pnpm 11.1.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+minimumreleaseage=1440

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "typedoc-plugin-resolve-crossmodule-references": "^0.3.0",
     "typescript": "^5.0.0"
   },
-  "packageManager": "pnpm@10.24.0"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - plugins/*
   - presets/*
   - tools/*
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Upgrade pnpm to `11.1.3`
- Add `minimumreleaseage=1440` to `.npmrc` — blocks packages published in the last 24h, reducing supply chain attack risk
- Remove obsolete `use-lockfile-v6` setting (default since pnpm 9)
- Approve native build scripts via `pnpm-workspace.yaml`

## Test plan
- [ ] CI passes